### PR TITLE
Sensor parameter is no longer required

### DIFF
--- a/templates/maps/map_google_dynamic.html5
+++ b/templates/maps/map_google_dynamic.html5
@@ -1,6 +1,6 @@
 <?php
     // set javascript in header
-    $GLOBALS['TL_JAVASCRIPT']['googleapis-maps'] = 'https://maps.googleapis.com/maps/api/js?sensor=false&amp;language='.$GLOBALS['TL_LANGUAGE'];
+    $GLOBALS['TL_JAVASCRIPT']['googleapis-maps'] = 'https://maps.googleapis.com/maps/api/js?language='.$GLOBALS['TL_LANGUAGE'];
     // set css in header
     $GLOBALS['TL_CSS']['anystores'] = 'system/modules/anyStores/assets/css/style.css';
 ?>


### PR DESCRIPTION
The `sensor` parameter is no longer required for the Google Maps JavaScript API.

https://developers.google.com/maps/articles/geolocation#SpecifyingSensor