### PR TITLE
Sensor parameter is no longer required

### DIFF
--- a/templates/maps/map_google_static.html5
+++ b/templates/maps/map_google_static.html5
@@ -8,4 +8,4 @@
     // image height
     $height = 220;
 ?>
-<img class="map-static" src="https://maps.googleapis.com/maps/api/staticmap?center=<?php echo $this->latitude?>,<?php echo $this->longitude?>&amp;zoom=<?php echo $zoom;?>&amp;size=<?=$width?>x<?=$height?>&amp;maptype=roadmap&amp;markers=color:red|label:|<?php echo $this->latitude;?>,<?php echo $this->longitude;?>&amp;sensor=false" alt="Google Maps"/>
+<img class="map-static" src="https://maps.googleapis.com/maps/api/staticmap?center=<?php echo $this->latitude?>,<?php echo $this->longitude?>&amp;zoom=<?php echo $zoom;?>&amp;size=<?=$width?>x<?=$height?>&amp;maptype=roadmap&amp;markers=color:red|label:|<?php echo $this->latitude;?>,<?php echo $this->longitude;?>" alt="Google Maps"/>


### PR DESCRIPTION
The `sensor` parameter is no longer required for the Google Maps JavaScript API.

https://developers.google.com/maps/articles/geolocation#SpecifyingSensor