### PR TITLE
Sensor parameter is no longer required

### DIFF
--- a/modules/ModuleAnyStoresMap.php
+++ b/modules/ModuleAnyStoresMap.php
@@ -54,7 +54,7 @@ class ModuleAnyStoresMap extends \Module // extends ModuleStoreLocatorList
      */
     protected function compile()
     {
-        $GLOBALS['TL_JAVASCRIPT']['googleapis-maps'] = 'https://maps.googleapis.com/maps/api/js?sensor=false&amp;language='.$GLOBALS['TL_LANGUAGE'];
+        $GLOBALS['TL_JAVASCRIPT']['googleapis-maps'] = 'https://maps.googleapis.com/maps/api/js?language='.$GLOBALS['TL_LANGUAGE'];
         $GLOBALS['TL_JAVASCRIPT']['markerclusterer'] = 'system/modules/anyStores/assets/js/markerclusterer.js';
 
         // get published stores from categories


### PR DESCRIPTION
The `sensor` parameter is no longer required for the Google Maps JavaScript API.

https://developers.google.com/maps/articles/geolocation#SpecifyingSensor