### PR TITLE
Sensor parameter is no longer required

### DIFF
--- a/dca/tl_anystores.php
+++ b/dca/tl_anystores.php
@@ -659,7 +659,7 @@ class tl_anystores extends Backend
 
         return '<div style="float: right; height: 139px; margin-right: 23px; overflow: hidden; width: 320px;">'
                 .'<h3><label>'.$GLOBALS['TL_LANG']['tl_anystores']['map'][0].'</label></h3> '
-                .'<img style="margin-top: 1px;" src="http://maps.google.com/maps/api/staticmap?center='.$sCoords.'&zoom=16&size=320x139&maptype=roadmap&markers=color:red|label:|'.$sCoords.'&sensor=false" />'
+                .'<img style="margin-top: 1px;" src="http://maps.google.com/maps/api/staticmap?center='.$sCoords.'&zoom=16&size=320x139&maptype=roadmap&markers=color:red|label:|'.$sCoords.'" />'
                 .'</div>';
     }
 


### PR DESCRIPTION
The `sensor` parameter is no longer required for the Google Maps JavaScript API.

https://developers.google.com/maps/articles/geolocation#SpecifyingSensor