### PR TITLE
Sensor parameter is no longer required

### DIFF
--- a/classes/API/GoogleMaps.php
+++ b/classes/API/GoogleMaps.php
@@ -28,7 +28,6 @@ class GoogleMaps
         // Google Geocoding API v3
         $strQuery = 'https://maps.googleapis.com/maps/api/geocode/json?'
             .'address='.rawurlencode($strAddress)
-            .'&sensor=false'
             .'&language='.$GLOBALS['TL_LANGUAGE'];
 
         if ( $strCountry )


### PR DESCRIPTION
The `sensor` parameter is no longer required for the Google Maps JavaScript API.

https://developers.google.com/maps/articles/geolocation#SpecifyingSensor