### PR TITLE
Update tl_anystores.php

### DIFF
--- a/dca/tl_anystores.php
+++ b/dca/tl_anystores.php
@@ -456,7 +456,7 @@ $GLOBALS['TL_DCA']['tl_anystores'] = array
                 'maxlength' => 64,
                 'tl_class'  => 'w50'
             ),
-            'sql' => "float(10,6) NOT NULL"
+            'sql' => "float(10,6) NOT NULL default '0.00'"
         ),
         'latitude' => array
         (
@@ -470,7 +470,7 @@ $GLOBALS['TL_DCA']['tl_anystores'] = array
                 'maxlength' => 64,
                 'tl_class'  => 'w50'
             ),
-            'sql' => "float(10,6) NOT NULL"
+            'sql' => "float(10,6) NOT NULL default '0.00'"
         ),
         'map' => array
         (


### PR DESCRIPTION
Fix crash when trying to add a new location:
An exception occurred while executing 'INSERT INTO tl_anystores (pid, tstamp) VALUES ('1', 0)': SQLSTATE[HY000]: General error: 1364 Field 'longitude' doesn't have a default value