### PR TITLE
Allow null for coordinates

### DIFF
--- a/dca/tl_module.php
+++ b/dca/tl_module.php
@@ -209,7 +209,7 @@ array_insert($GLOBALS['TL_DCA']['tl_module']['fields'], 0, array
             'maxlength' => 64,
             'tl_class'  => 'w50'
         ),
-        'sql' => "float(10,6) NOT NULL"
+        'sql' => "float(10,6) NULL"
     ),
     'anystores_longitude' => array
     (
@@ -223,7 +223,7 @@ array_insert($GLOBALS['TL_DCA']['tl_module']['fields'], 0, array
             'maxlength' => 64,
             'tl_class'  => 'w50'
         ),
-        'sql' => "float(10,6) NOT NULL"
+        'sql' => "float(10,6) NULL"
     ),
     'anystores_zoom' => array
     (


### PR DESCRIPTION
Should fix https://community.contao.org/de/showthread.php?81293-Nach-Serverumzug-kann-ich-keine-neuen-Mdoule-mehr-erstellen-anystores-Fehler&p=546702#post546702

Alternatively the definition could be `"float(10,6) NOT NULL default 0.0"`, but I think allowing `NULL` makes more sense in this case?